### PR TITLE
gosub and gosub_scene with param arguments

### DIFF
--- a/autotest.js
+++ b/autotest.js
@@ -227,13 +227,15 @@ if (fullGame) {
             if (/[\[\{]/.test(data)) {
               // print warning?
             } else {
-              words = data.split(/ /);
-              if (words[0] !== "") {
-                addFile(words[0]+".txt");
-              }
-              if (words.length > 1) {
-                if (!gotoSceneLabels[words[0]]) gotoSceneLabels[words[0]] = [];
-                gotoSceneLabels[words[0]].push({origin:sceneName, originLine:j, label:words[1]});
+              var match = /(\S+)\s+(\S+)\s*(.*)/.exec(data);
+              if (match) {
+                if (match[3]) {
+                  // parameters; print warning?
+                } else {
+                  addFile(match[1]+".txt");
+                  if (!gotoSceneLabels[match[1]]) gotoSceneLabels[match[1]] = [];
+                  gotoSceneLabels[match[1]].push({origin:sceneName, originLine:j, label:match[2]});
+                }
               }
             }
           } else if (command == "save_game") {

--- a/quicktest.html
+++ b/quicktest.html
@@ -239,13 +239,15 @@ function loadScenes(game, sceneNum) {
           if (/[\[\{]/.test(data)) {
             // print warning?
           } else {
-            words = data.split(/ /);
-            if (words[0] !== "") {
-              addFile(words[0]+".txt");
-            }
-            if (words.length > 1) {
-              if (!gotoSceneLabels[words[0]]) gotoSceneLabels[words[0]] = [];
-              gotoSceneLabels[words[0]].push({origin:sceneName, originLine:j, label:words[1]});
+            var match = /(\S+)\s+(\S+)\s*(.*)/.exec(data);
+            if (match) {
+              if (match[3]) {
+                // parameters; print warning?
+              } else {
+                addFile(match[1]+".txt");
+                if (!gotoSceneLabels[match[1]]) gotoSceneLabels[match[1]] = [];
+                gotoSceneLabels[match[1]].push({origin:sceneName, originLine:j, label:match[2]});
+              }
             }
           }
         } else if (command == "save_game") {

--- a/web/scene.js
+++ b/web/scene.js
@@ -838,6 +838,7 @@ Scene.prototype.params = function scene_params(data) {
     // All parameters, even those not named, exposed as param_1, param_2 etc.
     var words = /\w+/.exec(data);
     var nextParamNum = 1;
+    this.temps.param_count = this.temps.param.length;
     while (words) {
         var varName = words[0];
         this.validateVariable(varName);

--- a/web/scene.js
+++ b/web/scene.js
@@ -864,6 +864,12 @@ Scene.prototype["return"] = function scene_return() {
       this.indent = stackFrame.indent;
     } else if (this.stats.choice_subscene_stack && this.stats.choice_subscene_stack.length) {
       stackFrame = this.stats.choice_subscene_stack.pop();
+      if (stackFrame.name == this.name) {
+        this.temps = stackFrame.temps;
+        this.lineNum = stackFrame.lineNum-1;
+        this.indent = stackFrame.indent;
+        return;
+      }
       this.finished = true;
       this.skipFooter = true;
       var scene = new Scene(stackFrame.name, this.stats, this.nav, {debugMode:this.debugMode, secondaryMode:this.secondaryMode, saveSlot:this.saveSlot});
@@ -987,6 +993,13 @@ Scene.prototype.parseGotoScene = function parseGotoScene(data) {
 //
 Scene.prototype.goto_scene = function gotoScene(data) {
     var result = this.parseGotoScene(data);
+
+    if (result.sceneName == this.name) {
+      this["goto"](result.label);
+      this.temps = {choice_reuse:"allow", choice_user_restored:false, _choiceEnds:{}};
+      this.temps.param = result.param;
+      return;
+    }
 
     this.finished = true;
     this.skipFooter = true;

--- a/web/scene.js
+++ b/web/scene.js
@@ -797,11 +797,30 @@ Scene.prototype["goto"] = function scene_goto(line) {
     }
 };
 
-Scene.prototype.gosub = function scene_gosub(label) {
+Scene.prototype.gosub = function scene_gosub(data) {
+    label = /\w+/.exec(data)[0];
+    rest = data.substring(label.length+1);
+    args = [];
+    while (more = /(\w+)(.*)$/.exec(rest)) {
+        if (stringFinder = /^\s*("[^"]*")(.*)$/.exec(rest)) {
+            args.push(this.evaluateValueExpr(stringFinder[1]));
+            rest = stringFinder[2];
+        } else {
+            args.push(this.evaluateValueExpr(more[1]));
+            rest = more[2];
+        }
+    }
     if (!this.temps.choice_substack) {
       this.temps.choice_substack = [];
     }
     this.temps.choice_substack.push({lineNum: this.lineNum, indent: this.indent});
+    // Works exactly the same as gosub_scene, putting args in this.temps.param.
+    // This means there's no notion of scope - param acts more like "registers" that
+    // get clobbered the next time a sub is called.
+    // This may be more intuitive to non-programmers than idea of scope?  Especially
+    // if temp normally doesn't follow scoping rules.  gosub_scene can serve this function anyway.
+    // The params can be retrieved and put in named temps with "params" command.
+    this.temps.param = args;
     this["goto"](label);
 };
 
@@ -811,6 +830,34 @@ Scene.prototype.gosub_scene = function scene_gosub_scene(data) {
     }
     this.stats.choice_subscene_stack.push({name:this.name, lineNum: this.lineNum + 1, indent: this.indent, temps: this.temps});
     this.goto_scene(data);
+};
+
+Scene.prototype.params = function scene_params(data) {
+    // Name the parameters passed by gosub/gosub_scene.
+    // Rules should be the same as for "create."
+    // All parameters, even those not named, exposed as param_1, param_2 etc.
+    var words = /\w+/.exec(data);
+    var nextParamNum = 1;
+    while (words) {
+        var varName = words[0];
+        this.validateVariable(varName);
+        if (this.temps.param.length < 1) {
+            throw new Error(this.lineMsg() + "No parameter passed for " + varName);
+        }
+        var paramVal = this.temps.param.shift();
+        this.temps[varName] = paramVal;
+        this.temps["param_" + nextParamNum] = paramVal;
+        nextParamNum++;
+        data = data.substring(varName.length+1);
+        words = /\w+/.exec(data);
+    }
+    // All remaining params are anonymous, but you still have to say "params"
+    // if you want any of them.
+    while (this.temps.param.length > 0) {
+        var paramVal = this.temps.param.shift();
+        this.temps["param_" + nextParamNum] = paramVal;
+        nextParamNum++;
+    }
 };
 
 Scene.prototype["return"] = function scene_return() {
@@ -908,26 +955,31 @@ Scene.prototype.reset = function reset() {
 };
 
 Scene.prototype.parseGotoScene = function parseGotoScene(data) {
-  var sceneName, label;
+  var sceneName, label, param = [];
   if (/[\[\{]/.test(data)) {
     var stack = this.tokenizeExpr(data);
     sceneName = this.evaluateReference(stack, {toLowerCase: false});
+    // Labels are required for arguments to avoid ambiguity
     if (stack.length) {
       label = this.evaluateReference(stack);
     }
-    if (stack.length) {
-      throw new Error(this.lineMsg() + "Invalid *goto_scene command; nothing should appear after the label " + label);
+    while (stack.length > 0) {
+      // Arguments when treating gosub_scene like a function call
+      param.push(this.evaluateValueExpr(stack.shift()));
     }
   } else {
     var words = data.split(/ /);
-    sceneName = words[0];
-    if (words.length > 2) {
-      throw new Error(this.lineMsg() + "Invalid *goto_scene command; nothing should appear after the label " + words[1]);
-    } else if (words.length == 2) {
-      label = words[1];
+    sceneName = words.shift();
+    // Labels are required for arguments to avoid ambiguity
+    if (words.length) {
+      label = words.shift();
+    }
+    while (words.length > 0) {
+      // Arguments when treating gosub_scene like a function call
+      param.push(this.evaluateValueExpr(words.shift()));
     }
   }
-  return {sceneName:sceneName, label:label};
+  return {sceneName:sceneName, label:label, param:param};
 };
 
 // *goto_scene foo
@@ -942,6 +994,7 @@ Scene.prototype.goto_scene = function gotoScene(data) {
     scene.prevLine = this.prevLine;
     scene.accumulatedParagraph = this.accumulatedParagraph;
     if (typeof result.label != "undefined") scene.targetLabel = {label:result.label, origin:this.name, originLine:this.lineNum};
+    if (typeof result.param != "undefined") scene.temps.param = result.param;
     scene.execute();
 };
 
@@ -4127,5 +4180,5 @@ Scene.validCommands = {"comment":1, "goto":1, "gotoref":1, "label":1, "looplimit
     "restart":1,"more_games":1,"delay_ending":1,"end_trial":1,"login":1,"achieve":1,"scene_list":1,"title":1,
     "bug":1,"link_button":1,"check_registration":1,"sound":1,"author":1,"gosub_scene":1,"achievement":1,
     "check_achievements":1,"redirect_scene":1,"print_discount":1,"purchase_discount":1,"track_event":1,
-    "timer":1,"youtube":1,"product":1,"text_image":1
+    "timer":1,"youtube":1,"product":1,"text_image":1,"params":1
     };


### PR DESCRIPTION
Broken out and squashed @kgold's PR #122.

Changed:

* ~Omitted change to `embeddable-autotester.js`; this code just calls parameterized subroutines with whatever values are on hand.~ Transformed this change into a modification of autotest.js and quicktest.html, so we can test parameter in gosub, if not in gosub_scene
* Added a `param_count` temp variable
* Standardized the way we parse scene names, labels, and parameters: now we always tokenize and evaluate tokens off the stack.