### PR TITLE
Change no-selectable-option error message to include the filename.

### DIFF
--- a/web/scene.js
+++ b/web/scene.js
@@ -1831,7 +1831,7 @@ Scene.prototype.parseOptions = function parseOptions(startIndent, choicesRemaini
             (this.temps._fakeChoiceDepth === undefined || this.temps._fakeChoiceDepth < 1)) {
         throw new Error(this.lineMsg() + "Expected choice body");
     }
-    if (!atLeastOneSelectableOption) this.conflictingOptions("line " + (startingLine+1) + ": No selectable options");
+    if (!atLeastOneSelectableOption) this.conflictingOptions(this.lineMsg() + "No selectable options");
     if (expectedSubOptions) {
         this.verifyOptionsMatch(expectedSubOptions, options);
     }


### PR DESCRIPTION
Minor patch so that the error message for a *choice with no selectable options includes the filename. This makes its error message match the others, and includes needed file information.