### PR TITLE
Add scene names to operator and token error messages.

### DIFF
--- a/editor/embeddable-autotester.js
+++ b/editor/embeddable-autotester.js
@@ -415,10 +415,10 @@ function autotester(sceneText, nav, sceneName, extraLabels) {
     this.parseStatChart();
   }
 
-  Scene.operators["/"] = function divide(v1,v2,line) {
-    v2 = num(v2, line);
+  Scene.operators["/"] = function divide(v1,v2,line,sceneObj) {
+    v2 = num(v2, line, sceneObj.name);
     if (v2 === 0) return 9007199254740991; //Number.MAX_SAFE_INTEGER
-    return num(v1,line) / num(v2,line);
+    return num(v1,line,sceneObj.name) / num(v2,line,sceneObj.name);
   };
   
   //Scene.prototype.choice = function() { this.finished = true;}

--- a/editor/embeddable-autotester.js
+++ b/editor/embeddable-autotester.js
@@ -416,9 +416,13 @@ function autotester(sceneText, nav, sceneName, extraLabels) {
   }
 
   Scene.operators["/"] = function divide(v1,v2,line,sceneObj) {
-    v2 = num(v2, line, sceneObj.name);
+    let name = null;
+    if (sceneObj) {
+      name = sceneObj.name;
+    }
+    v2 = num(v2, line, name);
     if (v2 === 0) return 9007199254740991; //Number.MAX_SAFE_INTEGER
-    return num(v1,line,sceneObj.name) / num(v2,line,sceneObj.name);
+    return num(v1,line,name) / num(v2,line,name);
   };
   
   //Scene.prototype.choice = function() { this.finished = true;}

--- a/headless.js
+++ b/headless.js
@@ -105,7 +105,7 @@ function slurpFileLines(name, throwOnError) {
             if (i === 0 && line.charCodeAt(0) == 65279) line = line.substring(1);
             if (throwOnError) {
                 invalidCharacter = line.match(/^(.*)\ufffd/);
-                if (invalidCharacter) throw new Error("line " + (i+1) + ": invalid character. (ChoiceScript text should be saved in the UTF-8 encoding.)\n" + invalidCharacter[0]);
+                if (invalidCharacter) throw new Error(name+" line " + (i+1) + ": invalid character. (ChoiceScript text should be saved in the UTF-8 encoding.)\n" + invalidCharacter[0]);
             }
             lines.push(line);
         }
@@ -120,7 +120,7 @@ function slurpFileLines(name, throwOnError) {
             for (i = 0; i < lines.length; i++) {
                 line = lines[i];
                 invalidCharacter = line.match(/^(.*)\ufffd/);
-                if (invalidCharacter) throw new Error("line " + (i+1) + ": invalid character. (ChoiceScript text should be saved in the UTF-8 encoding.)\n" + invalidCharacter[0]);
+                if (invalidCharacter) throw new Error(name+" line " + (i+1) + ": invalid character. (ChoiceScript text should be saved in the UTF-8 encoding.)\n" + invalidCharacter[0]);
             }
         }
         return lines;

--- a/tests/scenetest.js
+++ b/tests/scenetest.js
@@ -1357,6 +1357,120 @@ test("or", function() {
     doh.is(true, value, true);
 })
 
+
+module("Operators with Mis-Matched Datatypes")
+
+
+test("add a string", function() {
+    raises(function() {Scene.operators["+"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("add to a string", function() {
+    raises(function() {Scene.operators["+"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("subtract a string", function() {
+    raises(function() {Scene.operators["-"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("subtract from a string", function() {
+    raises(function() {Scene.operators["-"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("multiply by a string", function() {
+    raises(function() {Scene.operators["*"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("multiply a string", function() {
+    raises(function() {Scene.operators["*"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("divide by a string", function() {
+    raises(function() {Scene.operators["/"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("divide a string", function() {
+    raises(function() {Scene.operators["/"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("modulo by a string", function() {
+    raises(function() {Scene.operators["modulo"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("modulo a string", function() {
+    raises(function() {Scene.operators["modulo"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("exponent by a string", function() {
+    raises(function() {Scene.operators["^"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("exponent a string", function() {
+    raises(function() {Scene.operators["^"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("fairPlue by a string", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%+"]("1", "\"2\"", 17, scene)}, /startup line 17: /, "Invalid data type");
+})
+test("fairPlus a string", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%+"]("\"1\"", "2", 17, scene)}, /startup line 17:/, "Invalid data type");
+})
+test("fairPlus to a non-percentile", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%+"]("103", "2", 17, scene)}, /startup line 19: Can't fairAdd to non-percentile/, "Not a percent value");
+})
+test("fairMinus by a string", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%-"]("1", "\"2\"", 17, scene)}, /startup line 17: /, "Invalid data type");
+})
+test("fairMinus a string", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%-"]("\"1\"", "2", 17, scene)}, /startup line 17:/, "Invalid data type");
+})
+test("fairMinus to a non-percentile", function() {
+    var scene = new Scene();
+    scene.name = "startup";
+    scene.lineNum = 18;
+    raises(function() {Scene.operators["%-"]("103", "2", 17, scene)}, /startup line 19: Can't fairAdd to non-percentile/, "Not a percent value");
+})
+test("lessThan a string", function() {
+    raises(function() {Scene.operators["<"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string is lessThan", function() {
+    raises(function() {Scene.operators["<"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("lessThanOrEquals a string", function() {
+    raises(function() {Scene.operators["<="]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string is lessThanOrEquals", function() {
+    raises(function() {Scene.operators["<="]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("greaterThan a string", function() {
+    raises(function() {Scene.operators[">"]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string is greaterThan", function() {
+    raises(function() {Scene.operators[">"]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("greaterThanOrEquals a string", function() {
+    raises(function() {Scene.operators[">="]("1", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string is greaterThanOrEquals", function() {
+    raises(function() {Scene.operators[">="]("\"1\"", "2", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("and a string", function() {
+    raises(function() {Scene.operators["and"]("true", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string and", function() {
+    raises(function() {Scene.operators["and"]("\"1\"", "true", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("or a string", function() {
+    raises(function() {Scene.operators["or"]("false", "\"2\"", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+test("a string or", function() {
+    raises(function() {Scene.operators["or"]("\"1\"", "false", 17, {"name":"startup"})}, /startup line 17:/, "Invalid data type");
+})
+
+
 module("Functions");
 
 test("not", function() {

--- a/web/scene.js
+++ b/web/scene.js
@@ -4436,7 +4436,11 @@ Scene.tokens = [
                     return str.substring(0,i+1);
                 }
             }
-            throw new Error(sceneObj.lineMsg()+"Invalid string, open quote with no close quote: " + str);
+            let errMessage = "line " + line + ": ";
+            if (sceneObj) {
+              errMessage = sceneObj.lineMessage();
+            }
+            throw new Error(errMessage+"Invalid string, open quote with no close quote: " + str);
         }
     },
     {name:"CURLY_QUOTE", test:function(str){ return Scene.regexpMatch(str,/^[\u201c\u201d]/); } },
@@ -4451,32 +4455,45 @@ Scene.tokens = [
     //
 ];
 Scene.operators = {
-    "+": function add(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) + num(v2,line,sceneObj.name); },
-    "-": function subtract(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) - num(v2,line,sceneObj.name); },
-    "*": function multiply(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) * num(v2,line,sceneObj.name); },
+    "+": function add(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) + num(v2,line,name); },
+    "-": function subtract(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) - num(v2,line,name); },
+    "*": function multiply(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) * num(v2,line,name); },
     "/": function divide(v1,v2,line,sceneObj) {
-      v2 = num(v2, line, sceneObj.name);
-      if (v2 === 0) throw new Error(sceneObj.name+" line "+line+": can't divide by zero");
-      return num(v1,line,sceneObj.name) / num(v2,line,sceneObj.name);
+      let name = null; if (sceneObj) name = sceneObj.name; 
+      v2 = num(v2, line, name);
+      if (v2 === 0) throw new Error(name+" line "+line+": can't divide by zero");
+      return num(v1,line,name) / num(v2,line,name);
     },
-    "^": function exponent(v1,v2,line,sceneObj) { return Math.pow(num(v1,line,sceneObj.name), num(v2,line,sceneObj.name)); },
+    "^": function exponent(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return Math.pow(num(v1,line,name), num(v2,line,name)); },
     "&": function concatenate(v1,v2) { return [v1,v2].join(""); },
     "#": function charAt(v1,v2,line,sceneObj) {
-      var i = num(v2,line,sceneObj.name);
+      let name = null;
+      let errMessage = "line " + line + ": ";
+      if (sceneObj) {
+        name = sceneObj.name;
+        errMessage = sceneObj.lineMessage();
+      }
+      var i = num(v2,line,name);
       if (i < 1) {
-        throw new Error(sceneObj.lineMsg()+"There is no character at position " + i + "; the position must be greater than or equal to 1.");
+        throw new Error(errMessage+"There is no character at position " + i + "; the position must be greater than or equal to 1.");
       }
       if (i > String(v1).length) {
-        throw new Error(sceneObj.lineMsg()+"There is no character at position " + i + ". \""+v1+"\" is only " + String(v1).length + " characters long.");
+        throw new Error(errMessage+"There is no character at position " + i + ". \""+v1+"\" is only " + String(v1).length + " characters long.");
       }
       return String(v1).charAt(i-1);
     },
     "%+": function fairAdd(v1, v2, line, sceneObj) {
-        v1 = num(v1,line,sceneObj.name);
-        v2 = num(v2,line,sceneObj.name);
+        let name = null;
+        let errMessage = "line " + line + ": ";
+        if (sceneObj) {
+          name = sceneObj.name;
+          errMessage = sceneObj.lineMessage();
+        }
+        v1 = num(v1,line,name);
+        v2 = num(v2,line,name);
         var validValue = (v1 >= 0 && v1 <= 100);
         if (!validValue) {
-            throw new Error(sceneObj.lineMsg()+"Can't fairAdd to non-percentile value: " + v1);
+            throw new Error(errMessage+"Can't fairAdd to non-percentile value: " + v1);
         }
         if (v2 > 0) {
           var multiplier = (100 - v1) / 100;
@@ -4495,23 +4512,27 @@ Scene.operators = {
         }
     },
     "%-": function fairSubtract(v1, v2, line, sceneObj) {
-        v2 = num(v2,line,sceneObj.name);
+        let name = null; if (sceneObj) name = sceneObj.name; 
+        v2 = num(v2,line,name);
         return Scene.operators["%+"](v1,0-v2,line,sceneObj);
     },
     "=": function equals(v1,v2) { return v1 == v2 || String(v1) == String(v2); },
     "<": function lessThan(v1,v2,line,sceneObj) {
-        return num(v1,line,sceneObj.name) < num(v2,line,sceneObj.name); },
-    ">": function greaterThan(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) > num(v2,line,sceneObj.name); },
-    "<=": function lessThanOrEquals(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) <= num(v2,line,sceneObj.name); },
-    ">=": function greaterThanOrEquals(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) >= num(v2,line,sceneObj.name); },
+        let name = null; if (sceneObj) name = sceneObj.name; 
+        return num(v1,line,name) < num(v2,line,name); },
+    ">": function greaterThan(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) > num(v2,line,name); },
+    "<=": function lessThanOrEquals(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) <= num(v2,line,name); },
+    ">=": function greaterThanOrEquals(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) >= num(v2,line,name); },
     "!=": function notEquals(v1,v2) { return v1 != v2; },
     "and": function and(v1, v2, line, sceneObj) {
-        return bool(v1,line,sceneObj.name) && bool(v2,line,sceneObj.name);
+        let name = null; if (sceneObj) name = sceneObj.name; 
+        return bool(v1,line,name) && bool(v2,line,name);
     },
     "or": function or(v1, v2, line, sceneObj) {
-        return bool(v1,line,sceneObj.name) || bool(v2,line,sceneObj.name);
+        let name = null; if (sceneObj) name = sceneObj.name; 
+        return bool(v1,line,name) || bool(v2,line,name);
     },
-    "modulo": function modulo(v1,v2,line,sceneObj) { return num(v1,line,sceneObj.name) % num(v2,line,sceneObj.name); },
+    "modulo": function modulo(v1,v2,line,sceneObj) { let name = null; if (sceneObj) name = sceneObj.name; return num(v1,line,name) % num(v2,line,name); },
 };
 
 Scene.initialCommands = {"create":1,"scene_list":1,"title":1,"author":1,"comment":1,"achievement":1,"product":1};

--- a/web/scene.js
+++ b/web/scene.js
@@ -4438,7 +4438,7 @@ Scene.tokens = [
             }
             let errMessage = "line " + line + ": ";
             if (sceneObj) {
-              errMessage = sceneObj.lineMessage();
+              errMessage = sceneObj.lineMsg();
             }
             throw new Error(errMessage+"Invalid string, open quote with no close quote: " + str);
         }
@@ -4471,7 +4471,7 @@ Scene.operators = {
       let errMessage = "line " + line + ": ";
       if (sceneObj) {
         name = sceneObj.name;
-        errMessage = sceneObj.lineMessage();
+        errMessage = sceneObj.lineMsg();
       }
       var i = num(v2,line,name);
       if (i < 1) {
@@ -4487,7 +4487,7 @@ Scene.operators = {
         let errMessage = "line " + line + ": ";
         if (sceneObj) {
           name = sceneObj.name;
-          errMessage = sceneObj.lineMessage();
+          errMessage = sceneObj.lineMsg();
         }
         v1 = num(v1,line,name);
         v2 = num(v2,line,name);

--- a/web/util.js
+++ b/web/util.js
@@ -926,15 +926,17 @@ function findOptimalDomain(docDomain) {
     return null;
 }
 
-function num(x, line) {
+function num(x, line, sceneName) {
     if (!line) line = "UNKNOWN";
+    errorInfo = "line "+line;
+    if (sceneName) errorInfo = sceneName + " " + errorInfo;
     var x_num = parseFloat(x);
-    if (isNaN(x_num)) throw new Error("line "+line+": Not a number: " + x);
-    if (!isFinite(x_num)) throw new Error("line "+line+": Not finite " + x);
+    if (isNaN(x_num)) throw new Error(errorInfo+": Not a number: " + x);
+    if (!isFinite(x_num)) throw new Error(errorInfo+": Not finite " + x);
     return x_num;
 }
 
-function bool(x, line) {
+function bool(x, line, sceneName) {
   if (!line) line = "UNKNOWN";
   if ("boolean" == typeof x) {
     return x;
@@ -943,7 +945,9 @@ function bool(x, line) {
   } else if ("false" === x) {
     return false;
   }
-  throw new Error("line "+line+": Neither true nor false: " + x);
+  errorInfo = "line "+line;
+  if (sceneName) errorInfo = sceneName + " " + errorInfo;
+  throw new Error(errorInfo+": Neither true nor false: " + x);
 }
 
 function findXhr() {


### PR DESCRIPTION
Minor patch to add scene names to errors that previously were only showing line numbers. This impacts one token and a number of operators, and the underlying utils functions (`num()` and `bool()`).