### PR TITLE
Stat clamp function.

### DIFF
--- a/tests/scenetest.js
+++ b/tests/scenetest.js
@@ -1105,7 +1105,8 @@ var tokenizerTests = {
     ,'2*3': [{"value":"2","name":"NUMBER","pos":1},{"value":"*","name":"OPERATOR","pos":2},{"value":"3","name":"NUMBER","pos":3}]
     ,'3%2': [{name:"NUMBER",value:"3",pos:1},{name:"OPERATOR",value:"%",pos:2},{name:"NUMBER",value:"2",pos:3}]
     ,'not(false)': [{name:"FUNCTION",value:"not(",pos:4,func:"not"},{name:"VAR",value:"false",pos:9},{name:"CLOSE_PARENTHESIS",value:")",pos:10}]
-    ,'round(1.5)': [{name:"FUNCTION",value:"round(",pos:6,func:"round"},{name:"NUMBER",value:"1.5",pos:9},{name:"CLOSE_PARENTHESIS",value:")",pos:10}]
+    , 'round(1.5)': [{ name: "FUNCTION", value: "round(", pos: 6, func: "round" }, { name: "NUMBER", value: "1.5", pos: 9 }, { name: "CLOSE_PARENTHESIS", value: ")", pos: 10 }]
+    , 'stat(150)': [{ name: "FUNCTION", value: "stat(", pos: 5, func: "stat" }, { name: "NUMBER", value: "150", pos: 8 }, { name: "CLOSE_PARENTHESIS", value: ")", pos: 9 }]
 }
 
 var tokenizerErrorTests = ['"foo'];
@@ -1487,6 +1488,14 @@ test("round", function() {
     var token = stack.shift();
     var actual = scene.evaluateValueToken(token, stack);
     doh.is(2, actual);
+});
+
+test("stat", function () {
+    var scene = new Scene();
+    var stack = scene.tokenizeExpr("stat(150)");
+    var token = stack.shift();
+    var actual = scene.evaluateValueToken(token, stack);
+    doh.is(100, actual);
 });
 
 module("Line Breaks");

--- a/web/scene.js
+++ b/web/scene.js
@@ -3889,6 +3889,23 @@ Scene.prototype.functions = {
     if (isNaN(value*1)) throw new Error(this.lineMsg()+"round() value is not a number: " + value);
     return Math.round(value);
   },
+  /**
+   * Takes a value and clamps it between 0 and 100.
+   * It is, return 0 if value below 0. Return 100
+   * if value above 100, and return the value itself
+   * if inside the range.
+   * 
+   * @param {Number} value - Current value of stat.
+   * @returns {Number} - Clamped value between 0 and 100.
+   */
+  stat: function (value) {
+    if (isNaN(value)) 
+      throw new Error(
+        this.lineMsg() + "argument in stat() is not a number: " + value
+      );
+    // This will clamp the value between 0 and 100.
+    return Math.max(Math.min(value, 100), 0); 
+  },
   timestamp: function(value) {
     return Date.parse(value)/1000;
   },
@@ -4455,7 +4472,7 @@ Scene.tokens = [
     {name:"CLOSE_CURLY", test:function(str){ return Scene.regexpMatch(str,/^\}/); } },
     {name:"OPEN_SQUARE", test:function(str){ return Scene.regexpMatch(str,/^\[/); } },
     {name:"CLOSE_SQUARE", test:function(str){ return Scene.regexpMatch(str,/^\]/); } },
-    {name:"FUNCTION", test:function(str){ return Scene.regexpMatch(str,/^(not|round|timestamp|log|length|auto)\s*\(/); } },
+    {name:"FUNCTION", test:function(str){ return Scene.regexpMatch(str,/^(not|round|timestamp|log|length|auto|stat)\s*\(/); } },
     {name:"NUMBER", test:function(str){ return Scene.regexpMatch(str,/^\d+(\.\d+)?\b/); } },
     {name:"STRING", test:function(str, line, sceneObj) {
             var i;


### PR DESCRIPTION
A built-in function to clamp values between 0 and 100.

```
*comment assume variable dexterity, with value 95

*set dexterity stat(dexterity + 20)

*comment the return will be 100, despite the operation result being 115
```

## Rationale

Stats are at the heart of ChoiceScript games and it is imperative to keep them inside the 0 to 100 range.

ChoiceScript offers built-in fairmath operations to deal with stats. However, fairmath comes with its own set of problems.
For developers, it is harder to balance a game, for players stat changes can be unpredictable, especially near the extremes.

Linear operations may be desired except for the boilerplate needed to always keep stat variables inside the range.

The `stat` function offers a simple interface for those developers who prefer to use linear operations instead of the ones based on percentage points. The function clamps the value between the acceptable range.