### PR TITLE
Added support for unary minus values

### DIFF
--- a/web/mygame/scenes/choicescript_stats.txt
+++ b/web/mygame/scenes/choicescript_stats.txt
@@ -6,3 +6,4 @@ This is a stats screen!
     Weakness
   text Leadership
   text Strength
+  

--- a/web/mygame/scenes/startup.txt
+++ b/web/mygame/scenes/startup.txt
@@ -27,7 +27,6 @@
 
 *create leadership 50
 *create strength 50
-
 Welcome to your very first ChoiceScript game!
 
 Copyright 2010 by Dan Fabulich.

--- a/web/scene.js
+++ b/web/scene.js
@@ -1507,14 +1507,21 @@ Scene.prototype.abort = function() {
 // *create
 // create a new permanent stat
 Scene.prototype.create = function create(line) {
-    var result = /^(\w*)(.*)/.exec(line);
+    var result = /^(\w*)\s*(-?\d*\.?\d*)(.*)/.exec(line);
     if (!result) throw new Error(this.lineMsg() + "Invalid create instruction, no variable specified: " + line);
     var variable = result[1];
     this.validateVariable(variable);
     variable = variable.toLowerCase();
-    var expr = result[2];
+    var expr = result[2] + result[3]; // Combine the number (possibly negative) with the rest of the expression
     var stack = this.tokenizeExpr(expr);
-    if (stack.length > 1) throw new Error(this.lineMsg() + "Invalid create instruction, too many values: " + line);
+    if (stack.length > 1) {
+      if (['+','-'].includes(stack[0].value) && stack[1].name == "NUMBER") {
+        if (stack[0].value == '-') stack[1].value = "-" + stack[1].value;
+        stack.shift();
+      }else{
+        throw new Error(this.lineMsg() + "Invalid create instruction, too many values: " + line)
+      }
+    };
     this.createVariable(variable, stack[0], line);
 }
 
@@ -1527,6 +1534,7 @@ Scene.prototype.createVariable = function createVariable(variable, token, line) 
   if (!/STRING|NUMBER|VAR/.test(token.name)) complexError();
   if ("VAR" == token.name && !/^true|false$/i.test(token.value)) complexError();
   if ("STRING" == token.name && /(\$|@)!?!?{/.test(token.value)) throw new Error(this.lineMsg() + "Invalid create instruction, value must be a simple string without ${} or @{}: " + line);
+  if ("NUMBER" == token.name && !/^[-+]?\d*\.?\d+$/.test(token.value)) complexError(); // Adjusted regex to include negative numbers
   var value = this.evaluateExpr([token]);
   if (!this.created) this.created = {};
   if (this.created[variable]) throw new Error(this.lineMsg() + "Invalid create. " + variable + " was previously created on line " + this.created[variable]);


### PR DESCRIPTION
Slightly adjusted the regex and create function to allow a line like `*create variable -50` to create a variable with a numeric value of -50. 

In the stats page, it works fine when displayed by curly braces but may be a bit iffy when displayed as percentage:
![image](https://github.com/dfabulich/choicescript/assets/32260711/7dfb98ae-3527-44ee-bd9e-67e559c43b7e)
