### PR TITLE
Allow complex lengths for temp_array

### DIFF
--- a/tests/scenetest.js
+++ b/tests/scenetest.js
@@ -2349,6 +2349,28 @@ test("tempArrayExplicitAndComplex", function() {
     doh.is(2, scene.temps.t_arr_count, "scene.temps.t_arr_count");
     doh.is("undefined", typeof scene.temps.t_arr_3, "scene.temps.t_arr_3");
 });
+test("tempArrayExpressionVarLength", function() {
+  var scene = new Scene();
+  scene.loadLines(dedent`
+              *temp count 10
+              *temp_array t_arr count 0`);
+  scene.execute();
+  doh.is("undefined", typeof scene.temps.t_arr_0, "scene.temps.t_arr_0");
+  doh.is(0, scene.temps.t_arr_1, "scene.temps.t_arr_1");
+  doh.is(10, scene.temps.t_arr_count, "scene.temps.t_arr_count");
+});
+test("tempArrayExpressionLength", function() {
+  var scene = new Scene();
+  scene.name = "startup";
+  scene.loadLines(dedent`
+              *create_array global 2 0
+              *temp arr_ref "global"
+              *temp_array t_arr {arr_ref&"_count"} 0`);
+  scene.execute();
+  doh.is("undefined", typeof scene.temps.t_arr_0, "scene.temps.t_arr_0");
+  doh.is(0, scene.temps.t_arr_1, "scene.temps.t_arr_1");
+  doh.is(2, scene.temps.t_arr_count, "scene.temps.t_arr_count");
+});
 test("tempArrayEmpty", function() {
     var scene = new Scene();
     scene.loadLines("*temp_array t_arr 2");
@@ -2373,6 +2395,19 @@ test("errorTempArrayValues", function() {
     var scene = new Scene();
     scene.loadLines("*temp_array foo 5 1 2 3 4 5 6");
     doh.assertError(Error, scene, "execute", null, "Expected 1 or 5 values for array foo not 6");
+});
+test("errorTempArrayValues", function() {
+  var scene = new Scene();
+  scene.loadLines(dedent`
+    *temp size 0
+    *temp_array t_arr size 0`);
+  doh.assertError(Error, scene, "execute", null, "Complex temp_array lengths should only evaluate to a number greater than 0");
+});
+test("errorCreateArrayComplexLength", function() {
+  var scene = new Scene();
+  scene.name = "startup";
+  scene.loadLines("*create_array foo {myexpr} 2");
+  doh.assertError(Error, scene, "execute", null, "Create instructions shouldn't allow complex lengths");
 });
 test("deleteCreateArray", function() {
     var scene = new Scene();

--- a/tests/scenetest.js
+++ b/tests/scenetest.js
@@ -2396,7 +2396,7 @@ test("errorTempArrayValues", function() {
     scene.loadLines("*temp_array foo 5 1 2 3 4 5 6");
     doh.assertError(Error, scene, "execute", null, "Expected 1 or 5 values for array foo not 6");
 });
-test("errorTempArrayValues", function() {
+test("errorTempArrayComplexLengthZero", function() {
   var scene = new Scene();
   scene.loadLines(dedent`
     *temp size 0

--- a/web/scene.js
+++ b/web/scene.js
@@ -1586,9 +1586,21 @@ Scene.prototype.defineArray = function defineArray(command, line) {
   if (!stack.length) {
     throw new Error(this.lineMsg() + "Invalid " + command + "_array instruction, missing length: " + line);
   }
-  var length = Number(stack.shift().value);
+
+  var length_token = stack[0];
+  var length;
+  if (length_token.name === "NUMBER") {
+    length = Number(length_token.value);
+    stack.shift();
+  } else {
+    if (command === "create") {
+      throw new Error(this.lineMsg() + "Invalid create_array instruction, length must be a number: " + line);
+    }
+    length = Number(this.evaluateValueToken(stack.shift(), stack));
+  }
+
   if (length !== Math.floor(length) || length < 1) {
-    throw new Error(this.lineMsg() + "Invalid " + command + "_array instruction, length should be a whole number greater than 0: " + line);
+    throw new Error(this.lineMsg() + `Invalid ${command}_array instruction, got a length of ${length} but wanted a length greater than 0: ${line}`);
   }
 
   var token;


### PR DESCRIPTION
Recently I've found myself often wanting to temporarily copy arrays in ChoiceScript to do some changes without affecting the original array. It's a bit more awkward than it needs to be at the moment because `temp_array` doesn't accept a complex length. I understand why `create_array` doesn't, but I don't think this restriction is necessary for `temp_array`?

**Usage**
```
*create_array my_global_array 5 1 2 3 4 5
*temp_array_clone my_local_array my_global_array_count 0
*comment you can now loop to copy safely
```

An alternative, more specific approach, might be a whole new command, something like:
```
*create_array my_global_array 5 1 2 3 4 5
*temp_array_clone my_local_array "my_global_array"
${my_local_array[3]} == 3
```