### PR TITLE
Fix missing string interpolation in serve.js

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -33,7 +33,7 @@ const requestHandler = (request, response) => {
     requestFile += 'index.html';
   } else if (requestFile.endsWith('mygame.js')) {
     const gameDir = path.basename(path.dirname(requestFile));
-    const mygame = child_process.execSync('node mygamegenerator.js ${gameDir}', {encoding: 'utf8'});
+    const mygame = child_process.execSync(`node mygamegenerator.js ${gameDir}`, {encoding: 'utf8'});
     fs.writeFileSync(`${dir}/web/${gameDir}/mygame.js`, mygame, 'utf8');
   }
   const stream = fs.createReadStream(requestFile);


### PR DESCRIPTION
In the current `main` branch of choicescript, there's what looks like a new bug in `serve.js` which causes it to throw an error when run:

```
server is ready: http://localhost:65397
Press Ctrl-C or close this window to stop the server
ENOENT: no such file or directory, open 'E:\Source\choicescript\web\${gameDir}\scenes\startup.txt'
node:child_process:1000
    throw err;
    ^

Error: Command failed: node mygamegenerator.js ${gameDir}
ENOENT: no such file or directory, open 'E:\Source\choicescript\web\${gameDir}\scenes\startup.txt'

    at genericNodeError (node:internal/errors:985:15)
    at wrappedFn (node:internal/errors:539:14)
    at checkExecSyncError (node:child_process:925:11)
    at Object.execSync (node:child_process:997:15)
    at Server.requestHandler (E:\Source\choicescript\serve.js:36:34)
    at Server.emit (node:events:508:28)
    at parserOnIncoming (node:_http_server:1210:12)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:125:17) {
  status: 1,
  signal: null,
  output: [
    null,
    '',
    "ENOENT: no such file or directory, open 'E:\\Source\\choicescript\\web\\${gameDir}\\scenes\\startup.txt'\n"
  ],
  pid: 15280,
  stdout: '',
  stderr: "ENOENT: no such file or directory, open 'E:\\Source\\choicescript\\web\\${gameDir}\\scenes\\startup.txt'\n"
}

Node.js v24.14.1
Press any key to continue . . .
```

The culprit is the one line changed in this commit, which has a missing back quote so the intended string interpolation doesn't happen and it tries to literally open a folder called `${gameDir}`.